### PR TITLE
ISSUE #7 を対応しました

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,8 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // 参考資料: https://developer.android.com/training/dependency-injection/hilt-testing#instrumented-tests
+        testInstrumentationRunner = "jp.co.yumemi.android.code_check.CustomTestRunner"
     }
 
     buildTypes {
@@ -95,6 +97,13 @@ dependencies {
     // JUnit で HTTP レスポンスのパース処理がうまくいっていない問題の対応
     // 参考資料: https://stackoverflow.com/questions/49667567/android-org-json-jsonobject-returns-null-in-unit-tests
     testImplementation 'org.json:json:20180813'
+
+    debugImplementation "androidx.fragment:fragment-testing:1.5.5"
+
+    // For instrumented tests.
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.37")
+    // ...with Kotlin.
+    kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.37")
 }
 
 // Allow references to generated code

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,7 +86,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     // Hilt
     implementation 'com.google.dagger:hilt-android:2.37'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,11 @@ android {
     buildFeatures {
         viewBinding true
     }
+    // 以下のエラーに対応するため追加しました
+    // java.lang.RuntimeException: Method d in android.util.Log not mocked. See http://g.co/androidstudio/not-mocked for details.
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,10 @@ dependencies {
     // Hilt
     implementation 'com.google.dagger:hilt-android:2.37'
     kapt 'com.google.dagger:hilt-android-compiler:2.37'
+
+    // JUnit で HTTP レスポンスのパース処理がうまくいっていない問題の対応
+    // 参考資料: https://stackoverflow.com/questions/49667567/android-org-json-jsonobject-returns-null-in-unit-tests
+    testImplementation 'org.json:json:20180813'
 }
 
 // Allow references to generated code

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/CustomTestRunner.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/CustomTestRunner.kt
@@ -1,0 +1,15 @@
+package jp.co.yumemi.android.code_check
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+// 参考資料: https://developer.android.com/training/dependency-injection/hilt-testing#instrumented-tests
+// A custom runner to set up the instrumented application class for tests.
+class CustomTestRunner : AndroidJUnitRunner() {
+
+    override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/HiltExtention.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/HiltExtention.kt
@@ -1,0 +1,40 @@
+package jp.co.yumemi.android.code_check
+
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Bundle
+import androidx.annotation.StyleRes
+import androidx.core.util.Preconditions
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+
+// 参考資料: https://github.com/mo-kalaleeb/testrobolectrichilt
+inline fun <reified T : Fragment> launchFragmentInHiltContainer(
+    fragmentArgs: Bundle? = null,
+    @StyleRes themeResId: Int = R.style.FragmentScenarioEmptyFragmentActivityTheme,
+    fragmentFactory: FragmentFactory? = null,
+    crossinline action: Fragment.() -> Unit = {}
+) {
+    val startActivityIntent = Intent.makeMainActivity(
+        ComponentName(
+            ApplicationProvider.getApplicationContext(),
+            HiltTestActivity::class.java
+        )
+    )
+
+    ActivityScenario.launch<HiltTestActivity>(startActivityIntent).onActivity { activity ->
+        val fragment: Fragment = activity.supportFragmentManager.fragmentFactory.instantiate(
+            Preconditions.checkNotNull(T::class.java.classLoader),
+            T::class.java.name
+        )
+        fragment.arguments = fragmentArgs
+        activity.supportFragmentManager
+            .beginTransaction()
+            .add(android.R.id.content, fragment, "")
+            .commitNow()
+
+        fragment.action()
+    }
+}

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragmentTest.kt
@@ -1,0 +1,36 @@
+package jp.co.yumemi.android.code_check.ui.search
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import jp.co.yumemi.android.code_check.launchFragmentInHiltContainer
+import junit.framework.Assert.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class SearchFragmentTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setUp() {
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+
+    @Test
+    fun `SearchFragmentでUIテストできる状態にする`() {
+        launchFragmentInHiltContainer<SearchFragment> {
+            assertEquals(2 + 2, 4)
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragmentTest.kt
@@ -1,11 +1,15 @@
 package jp.co.yumemi.android.code_check.ui.search
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.textfield.TextInputEditText
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.launchFragmentInHiltContainer
 import junit.framework.Assert.assertEquals
 import org.junit.After
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -28,9 +32,30 @@ class SearchFragmentTest {
 
 
     @Test
-    fun `SearchFragmentでUIテストできる状態にする`() {
+    fun `SearchFragmentでUIテストを開始できる状態である`() {
         launchFragmentInHiltContainer<SearchFragment> {
             assertEquals(2 + 2, 4)
+        }
+    }
+
+    @Test
+    fun `検索バーが表示されている`() {
+        launchFragmentInHiltContainer<SearchFragment> {
+            val searchBar = this.view?.findViewById<MaterialCardView>(R.id.search_bar)
+            assertTrue(searchBar?.isShown ?: false)
+        }
+    }
+
+    @Test
+    fun `検索バーのヒントテキストが想定しているものである`() {
+        launchFragmentInHiltContainer<SearchFragment> {
+            val expectedHintText = "GitHub のリポジトリを検索できるよー"
+            val displayedHintText = this.view?.findViewById<TextInputEditText>(
+                R.id.search_input_text
+            )?.hint.toString()
+            assertEquals(
+                expectedHintText, displayedHintText
+            )
         }
     }
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="jp.co.yumemi.android.code_check">
+
+    <application>
+        <activity
+            android:name="jp.co.yumemi.android.code_check.HiltTestActivity"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/app/src/debug/kotlin/jp/co/yumemi/android/code_check/HiltTestActivity.kt
+++ b/app/src/debug/kotlin/jp/co/yumemi/android/code_check/HiltTestActivity.kt
@@ -1,0 +1,7 @@
+package jp.co.yumemi.android.code_check
+
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class HiltTestActivity : AppCompatActivity(R.layout.activity_main)

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/data/repository/GithubRepositoryImplTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/data/repository/GithubRepositoryImplTest.kt
@@ -1,0 +1,55 @@
+package jp.co.yumemi.android.code_check.data.repository
+
+import jp.co.yumemi.android.code_check.data.api.GithubApiClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class GithubRepositoryImplTest {
+
+    private lateinit var githubApiClient: GithubApiClient
+    private lateinit var githubRepository: GithubRepositoryImpl
+
+    @Before
+    fun setUp() {
+        githubApiClient = GithubApiClient()
+        githubRepository = GithubRepositoryImpl(githubApiClient)
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `【正常系】キーワード「Flutter」で検索した場合、APIサーバから正常なレスポンスが返却される`() = runBlocking {
+        val response = githubRepository.tryRequestGithubRepositories("Flutter")
+        Assert.assertEquals(200, response.status.value)
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `【正常系】リポジトリに存在しないキーワードで検索した場合でも、APIサーバから正常なレスポンスが返却される`() = runBlocking {
+        val keywordForNonRepository = "abcdefghijklmnopqrstuvwxyzabcd"
+        val response = githubRepository.tryRequestGithubRepositories(keywordForNonRepository)
+        Assert.assertEquals(200, response.status.value)
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test(expected = Exception::class)
+    fun `【準正常系】空文字のキーワードで検索した場合、APIサーバから失敗のレスポンスが返却され、例外が発生する`(): Unit = runBlocking {
+        val emptyKeyword = ""
+        githubRepository.tryRequestGithubRepositories(emptyKeyword)
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test(expected = Exception::class)
+    fun `【準正常系】256 文字超のキーワードで検索した場合、APIサーバから失敗のレスポンスが返却され、例外が発生する`(): Unit = runBlocking {
+        val keywordWith257Letters =
+            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw"
+        githubRepository.tryRequestGithubRepositories(keywordWith257Letters)
+    }
+}

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/usecase/SearchResultsDetailUseCaseTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/usecase/SearchResultsDetailUseCaseTest.kt
@@ -1,0 +1,64 @@
+package jp.co.yumemi.android.code_check.usecase
+
+import jp.co.yumemi.android.code_check.data.api.GithubApiClient
+import jp.co.yumemi.android.code_check.data.repository.GithubRepositoryImpl
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class SearchResultsDetailUseCaseTest {
+
+    private lateinit var searchResultsDetailUseCase: SearchResultsDetailUseCase
+    private lateinit var githubRepository: GithubRepositoryImpl
+    private lateinit var githubApiClient: GithubApiClient
+
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setUp() {
+        githubApiClient = GithubApiClient()
+        githubRepository = GithubRepositoryImpl(githubApiClient)
+        searchResultsDetailUseCase = SearchResultsDetailUseCase(githubRepository)
+    }
+
+    @ExperimentalCoroutinesApi
+    @After
+    fun tearDown() {
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `【正常系】キーワード「Flutter」で検索した場合、GithubRepositoryデータが 30 件返却される`() = runBlocking {
+        val githubRepositories = searchResultsDetailUseCase.get("flutter")
+        val expectedLength = 30
+        Assert.assertTrue(githubRepositories.size == expectedLength)
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `【【正常系】リポジトリに存在しないキーワードで検索した場合、GithubRepositoryデータが 0 件返却される`() = runBlocking {
+        val keywordForNonRepository = "abcdefghijklmnopqrstuvwxyzabcd"
+        val githubRepositories = searchResultsDetailUseCase.get(keywordForNonRepository)
+        val expectedLength = 0
+        Assert.assertTrue(githubRepositories.size == expectedLength)
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `【準正常系】空文字のキーワードで検索した場合、空の配列が返却される`() = runBlocking {
+        val emptyKeyword = ""
+        val githubRepositories = searchResultsDetailUseCase.get(emptyKeyword)
+        Assert.assertTrue(githubRepositories.isEmpty())
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `【準正常系】256 文字超のキーワードで検索した場合、空の配列が返却される`() = runBlocking {
+        val keywordWith257Letters =
+            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw"
+        val githubRepositories = searchResultsDetailUseCase.get(keywordWith257Letters)
+        Assert.assertTrue(githubRepositories.isEmpty())
+    }
+}


### PR DESCRIPTION
# 対応内容

以下のクラスのテストケースを追加しました

- GithubRepository
- SearchResultsDetailUseCase
- SearchFragment

# 課題

Dagger Hilt ライブラリで依存性注入したアーキテクチャの場合、Fragment の UI テストに `withId` でのレイアウトやウィジェットの探索が終わらない状態となっていた。
そのため、代替案として `findViewById` でテストしたいレイアウトやウィジェットの探索を行い、テストケースを作成しました。